### PR TITLE
correctly handle empty <description> tags in hw_commands and fsw_commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 node_modules
 test-report
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-ampcs",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-ampcs",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "xml-js": "^1.6.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-jpl/aerie-ampcs",
   "description": "Utility functions to convert a standard XML AMPCS command dictionary to JavaScript.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -171,6 +171,10 @@ describe('@nasa-jpl/aerie-ampcs', () => {
               </categories>
               <description>Does something else interesting.</description>
             </hw_command>
+            <hw_command opcode="" stem="HDW_CMD_2">
+              <!-- empty description tag -->
+              <description></description>
+            </hw_command>
           </command_definitions>
         </command_dictionary>
       `;
@@ -197,6 +201,11 @@ describe('@nasa-jpl/aerie-ampcs', () => {
             stem: 'HDW_CMD_1',
             type: 'hw_command',
           },
+          HDW_CMD_2: {
+            description: '',
+            stem: 'HDW_CMD_2',
+            type: 'hw_command',
+          },
         },
         hwCommands: [
           {
@@ -207,6 +216,11 @@ describe('@nasa-jpl/aerie-ampcs', () => {
           {
             description: 'Does something else interesting.',
             stem: 'HDW_CMD_1',
+            type: 'hw_command',
+          },
+          {
+            description: '',
+            stem: 'HDW_CMD_2',
             type: 'hw_command',
           },
         ],
@@ -244,6 +258,10 @@ describe('@nasa-jpl/aerie-ampcs', () => {
                 <category name="cat" value="a" />
               </categories>
               <description><![CDATA[Does something interesting to the spacecraft.]]></description>
+            </fsw_command>
+            <fsw_command opcode="" stem="FSW_CMD_1">
+              <!-- empty description -->
+              <description />
             </fsw_command>
           </command_definitions>
         </command_dictionary>
@@ -320,6 +338,13 @@ describe('@nasa-jpl/aerie-ampcs', () => {
             stem: 'FSW_CMD_0',
             type: 'fsw_command',
           },
+          FSW_CMD_1: {
+            argumentMap: {},
+            arguments: [],
+            description: '',
+            stem: 'FSW_CMD_1',
+            type: 'fsw_command',
+          },
         },
         fswCommands: [
           {
@@ -327,6 +352,13 @@ describe('@nasa-jpl/aerie-ampcs', () => {
             arguments: args,
             description: 'Does something interesting to the spacecraft.',
             stem: 'FSW_CMD_0',
+            type: 'fsw_command',
+          },
+          {
+            argumentMap: {},
+            arguments: [],
+            description: '',
+            stem: 'FSW_CMD_1',
             type: 'fsw_command',
           },
         ],

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -244,6 +244,8 @@ describe('@nasa-jpl/aerie-ampcs', () => {
                 <boolean_arg name="boolean_arg_0" bit_length="8" default_value="FALSE">
                   <!-- comment -->
                   <boolean_format true_str="TRUE" false_str="FALSE" />
+                  <!-- empty description -->
+                  <description />
                 </boolean_arg>
                 <numeric_arg name="numeric_arg_0" type="float" bit_length="64" units="none" default_value="1">
                   <!-- comment -->

--- a/src/index.ts
+++ b/src/index.ts
@@ -613,17 +613,21 @@ export function parse(
 
               // Description.
               if (commandElement?.name === 'description') {
-                const [descriptionElement] = commandElement.elements;
-                const { type } = descriptionElement;
-                const description = descriptionElement[type];
+                if (commandElement?.elements?.length) {
+                  const descriptionElement = commandElement.elements[0];
+                  const { type } = descriptionElement;
+                  const description = descriptionElement[type];
 
-                if (description !== undefined) {
-                  commandDescription = description;
+                  if (description !== undefined) {
+                    commandDescription = description;
+                  } else {
+                    console.log(
+                      'Unknown FSW command description type: ',
+                      commandElement,
+                    );
+                  }
                 } else {
-                  console.log(
-                    'Unknown FSW command description type: ',
-                    commandElement,
-                  );
+                  console.log('Empty FSW command description: ', commandElement);
                 }
               }
             }
@@ -647,17 +651,21 @@ export function parse(
             for (const commandElement of command.elements) {
               // Description.
               if (commandElement?.name === 'description') {
-                const [descriptionElement] = commandElement.elements;
-                const { type } = descriptionElement;
-                const description = descriptionElement[type];
+                if (commandElement?.elements?.length) {
+                  const descriptionElement = commandElement.elements[0];
+                  const { type } = descriptionElement;
+                  const description = descriptionElement[type];
 
-                if (description !== undefined) {
-                  commandDescription = description;
+                  if (description !== undefined) {
+                    commandDescription = description;
+                  } else {
+                    console.log(
+                      'Unknown HW command description type: ',
+                      commandElement,
+                    );
+                  }
                 } else {
-                  console.log(
-                    'Unknown HW command description type: ',
-                    commandElement,
-                  );
+                  console.log('Empty HW command description: ', commandElement);
                 }
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,17 +314,10 @@ export function parseArguments(element: any): {
 
         // Description.
         if (argElement?.name === 'description') {
-          const [descriptionElement] = argElement.elements;
-          const { type } = descriptionElement;
-          description = descriptionElement[type];
-
-          if (description === undefined) {
-            console.log(
-              'Unknown FSW command argument description type: ',
-              argElement,
-            );
-            description = '';
-          }
+          description = parseDescription(
+            argElement,
+            'FSW command argument description',
+          );
         }
 
         // Range of Values.
@@ -613,22 +606,10 @@ export function parse(
 
               // Description.
               if (commandElement?.name === 'description') {
-                if (commandElement?.elements?.length) {
-                  const descriptionElement = commandElement.elements[0];
-                  const { type } = descriptionElement;
-                  const description = descriptionElement[type];
-
-                  if (description !== undefined) {
-                    commandDescription = description;
-                  } else {
-                    console.log(
-                      'Unknown FSW command description type: ',
-                      commandElement,
-                    );
-                  }
-                } else {
-                  console.log('Empty FSW command description: ', commandElement);
-                }
+                commandDescription = parseDescription(
+                  commandElement,
+                  'FSW command description',
+                );
               }
             }
 
@@ -651,22 +632,10 @@ export function parse(
             for (const commandElement of command.elements) {
               // Description.
               if (commandElement?.name === 'description') {
-                if (commandElement?.elements?.length) {
-                  const descriptionElement = commandElement.elements[0];
-                  const { type } = descriptionElement;
-                  const description = descriptionElement[type];
-
-                  if (description !== undefined) {
-                    commandDescription = description;
-                  } else {
-                    console.log(
-                      'Unknown HW command description type: ',
-                      commandElement,
-                    );
-                  }
-                } else {
-                  console.log('Empty HW command description: ', commandElement);
-                }
+                commandDescription = parseDescription(
+                  commandElement,
+                  'HW command description',
+                );
               }
             }
 
@@ -717,6 +686,27 @@ function parseHeader(headerElement): Header {
     spacecraft_ids,
     version: attributes.version ?? '',
   };
+}
+
+function parseDescription(
+  descriptionElement: Element,
+  logName?: string,
+): string {
+  logName = logName || 'description';
+  if (descriptionElement.elements?.length) {
+    const innerElement = descriptionElement.elements[0];
+    const { type } = innerElement;
+    const description = innerElement[type || ''];
+
+    if (description !== undefined) {
+      return description;
+    } else {
+      console.log(`Unknown ${logName} type: `, descriptionElement);
+    }
+  } else {
+    console.log(`Empty ${logName}: `, descriptionElement);
+  }
+  return '';
 }
 
 function parseEnum(enumTable): Enum {

--- a/src/index.ts
+++ b/src/index.ts
@@ -774,7 +774,8 @@ function parseParam(
           enum_name = paramTypeChild.attributes?.enum_name as string;
         }
 
-        for (const paramChildElement of paramTypeChild.elements ?? []) {
+        for (const paramChildElement of paramTypeChild.elements ??
+          ([] as Element[])) {
           if (paramChildElement.name === 'range_of_values') {
             if (
               param_type === 'enum_param' ||
@@ -782,6 +783,11 @@ function parseParam(
               param_type === 'integer_param' ||
               param_type === 'float_param'
             ) {
+              if (!paramChildElement.elements?.length) {
+                throw new Error(
+                  'range_of_values element must contain a valid range',
+                );
+              }
               const [{ attributes }] = paramChildElement.elements!;
               if (attributes) {
                 const min = toNumber(attributes.min as string);


### PR DESCRIPTION
Related to https://github.com/NASA-AMMOS/aerie/issues/1466

Kind of a devious bug related to destructuring, you'd expect Typescript to complain about something like this, because `myCollection.things` can be undefined:

```
interface ThingCollection {
  things?: Array<Thing>
}
const myCollection: ThingCollection = getThingCollection();
const [thing] = myCollection.things;
```

... but this compiles and throws a runtime error. Might be good to do a scan for any other similar bugs before merging.